### PR TITLE
fixed col renames to avoid FutureWarning

### DIFF
--- a/austin_mp/configs/configs/initialize_households.yaml
+++ b/austin_mp/configs/configs/initialize_households.yaml
@@ -7,10 +7,6 @@ annotate_tables:
       TABLES:
         - households
   - tablename: households
-    column_map:
-      PERSONS: hhsize
-      workers: num_workers
-      member_id: PNUM
     annotate:
       SPEC: annotate_households
       DF: households

--- a/austin_mp/configs/configs/initialize_landuse.yaml
+++ b/austin_mp/configs/configs/initialize_landuse.yaml
@@ -2,8 +2,6 @@
 
 annotate_tables:
   - tablename: land_use
-    column_map:
-      COUNTY: county_id
     annotate:
       SPEC: annotate_landuse
       DF: land_use

--- a/austin_mp/configs/configs/settings.yaml
+++ b/austin_mp/configs/configs/settings.yaml
@@ -1,21 +1,3 @@
-# input tables 
-input_table_list:
-  - tablename: households
-    filename: households.csv
-    index_col: household_id
-    column_map:
-      household_id: household_id
-  - tablename: persons
-    filename: persons.csv
-    index_col: person_id
-    column_map:
-      person_id: person_id
-  - tablename: land_use
-    filename: land_use.csv
-    index_col: TAZ
-    column_map:
-      ZONE: TAZ
-
 # input skims
 skims_file: skims.omx
 

--- a/austin_mp/configs/configs/settings.yaml
+++ b/austin_mp/configs/configs/settings.yaml
@@ -1,3 +1,25 @@
+# input tables 
+input_table_list:
+  - tablename: households
+    filename: households.csv
+    index_col: household_id
+    rename_columns:
+      household_id: household_id
+      PERSONS: hhsize
+      workers: num_workers
+  - tablename: persons
+    filename: persons.csv
+    index_col: person_id
+    rename_columns:
+      person_id: person_id
+      member_id: PNUM
+  - tablename: land_use
+    filename: land_use.csv
+    index_col: TAZ
+    rename_columns:
+      ZONE: TAZ
+      COUNTY: county_id
+
 # input skims
 skims_file: skims.omx
 

--- a/austin_mp/configs/settings.yaml
+++ b/austin_mp/configs/settings.yaml
@@ -1,8 +1,26 @@
-
 inherit_settings: True
 
-# output
-s3_output: False
+# input tables 
+input_table_list:
+  - tablename: households
+    filename: households.csv
+    index_col: household_id
+    rename_columns:
+      household_id: household_id
+      PERSONS: hhsize
+      workers: num_workers
+  - tablename: persons
+    filename: persons.csv
+    index_col: person_id
+    rename_columns:
+      person_id: person_id
+      member_id: PNUM
+  - tablename: land_use
+    filename: land_use.csv
+    index_col: TAZ
+    rename_columns:
+      ZONE: TAZ
+      COUNTY: county_id
 
 # geographic settings
 state_fips: 48

--- a/bay_area/configs/configs/settings.yaml
+++ b/bay_area/configs/configs/settings.yaml
@@ -3,17 +3,17 @@ input_table_list:
   - tablename: households
     filename: households.csv
     index_col: household_id
-    column_map:
+    rename_columns:
       household_id: household_id
   - tablename: persons
     filename: persons.csv
     index_col: person_id
-    column_map:
+    rename_columns:
       person_id: person_id
   - tablename: land_use
     filename: land_use.csv
     index_col: TAZ
-    column_map:
+    rename_columns:
       ZONE: TAZ
 
 

--- a/bay_area/configs/initialize_households.yaml
+++ b/bay_area/configs/initialize_households.yaml
@@ -6,10 +6,6 @@ annotate_tables:
       TABLES:
         - households
   - tablename: households
-    column_map:
-      PERSONS: hhsize
-      workers: num_workers
-      member_id: PNUM
     annotate:
       SPEC: annotate_households
       DF: households

--- a/bay_area/configs/initialize_landuse.yaml
+++ b/bay_area/configs/initialize_landuse.yaml
@@ -1,7 +1,5 @@
 annotate_tables:
   - tablename: land_use
-    column_map:
-      COUNTY: county_id
     annotate:
       SPEC: annotate_landuse
       DF: land_use

--- a/bay_area/configs/settings.yaml
+++ b/bay_area/configs/settings.yaml
@@ -20,18 +20,22 @@ input_table_list:
   - tablename: households
     filename: households.csv
     index_col: household_id
-    column_map:
+    rename_columns:
       household_id: household_id
+      PERSONS: hhsize
+      workers: num_workers
   - tablename: persons
     filename: persons.csv
     index_col: person_id
-    column_map:
+    rename_columns:
       person_id: person_id
+      member_id: PNUM
   - tablename: land_use
     filename: land_use.csv
     index_col: TAZ
-    column_map:
+    rename_columns:
       ZONE: TAZ
+      COUNTY: county_id
 
 # input skims
 skims_file: skims.omx

--- a/detroit/configs/configs/initialize_households.yaml
+++ b/detroit/configs/configs/initialize_households.yaml
@@ -7,10 +7,6 @@ annotate_tables:
       TABLES:
         - households
   - tablename: households
-    column_map:
-      PERSONS: hhsize
-      workers: num_workers
-      member_id: PNUM
     annotate:
       SPEC: annotate_households
       DF: households

--- a/detroit/configs/configs/initialize_landuse.yaml
+++ b/detroit/configs/configs/initialize_landuse.yaml
@@ -2,8 +2,6 @@
 
 annotate_tables:
   - tablename: land_use
-    column_map:
-      COUNTY: county_id
     annotate:
       SPEC: annotate_landuse
       DF: land_use

--- a/detroit/configs/configs/settings.yaml
+++ b/detroit/configs/configs/settings.yaml
@@ -3,17 +3,17 @@ input_table_list:
   - tablename: households
     filename: households.csv
     index_col: household_id
-    column_map:
+    rename_columns:
       household_id: household_id
   - tablename: persons
     filename: persons.csv
     index_col: person_id
-    column_map:
+    rename_columns:
       person_id: person_id
   - tablename: land_use
     filename: land_use.csv
     index_col: TAZ
-    column_map:
+    rename_columns:
       ZONE: TAZ
 
 # input skims

--- a/detroit/configs/settings.yaml
+++ b/detroit/configs/settings.yaml
@@ -1,8 +1,26 @@
-
 inherit_settings: True
 
-# output
-s3_output: False
+# input tables 
+input_table_list:
+  - tablename: households
+    filename: households.csv
+    index_col: household_id
+    rename_columns:
+      household_id: household_id
+      PERSONS: hhsize
+      workers: num_workers
+  - tablename: persons
+    filename: persons.csv
+    index_col: person_id
+    rename_columns:
+      person_id: person_id
+      member_id: PNUM
+  - tablename: land_use
+    filename: land_use.csv
+    index_col: TAZ
+    rename_columns:
+      ZONE: TAZ
+      COUNTY: county_id
 
 # geographic settings
 state_fips: 26


### PR DESCRIPTION
Get rid of `column_map` settings in `initialize_<table>.yaml`'s, convert to `rename_columns` and move to main settings.yaml